### PR TITLE
Fix content-type for release artifacts

### DIFF
--- a/source/uploadReleaseArtifacts.ts
+++ b/source/uploadReleaseArtifacts.ts
@@ -44,7 +44,7 @@ export const uploadReleaseArtifacts = async (
         url: release.upload_url,
         headers: {
           "content-length": lstatSync(filePath).size,
-          "content-type": "application/octet-stream"
+          "content-type": "application/octet-stream",
         },
         name: nameWithExt,
         data: readFileSync(filePath) as unknown as string,

--- a/source/uploadReleaseArtifacts.ts
+++ b/source/uploadReleaseArtifacts.ts
@@ -44,10 +44,10 @@ export const uploadReleaseArtifacts = async (
         url: release.upload_url,
         headers: {
           "content-length": lstatSync(filePath).size,
-          "content-type": "text/plain; charset=utf-8",
+          "content-type": "application/octet-stream"
         },
         name: nameWithExt,
-        data: readFileSync(filePath, { encoding: "utf-8" }),
+        data: readFileSync(filePath) as unknown as string,
       };
 
       try {


### PR DESCRIPTION
The current version crashes when uploading anything not utf-8 encoded. This should fix this, by reverting back to the implementation from https://github.com/marvinpinto/actions/blob/master/packages/automatic-releases/src/uploadReleaseArtifacts.ts